### PR TITLE
Allow to call catch() before then()

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,10 @@ describe("q-supertest", function () {
     it("should reject if an assertion fails", function () {
       return expect(request.get("/home").expect(500)).to.eventually.be.rejected;
     });
+    
+    it("should expose catch method", function() {
+      return request.get("/home").expect(500).catch(function() {});
+    });
   });
 
   describe("TestAgent instances", function () {


### PR DESCRIPTION
`catch` method is unavailable directly from request, just after `then()`.
I want to use it right after request when I have nothing to do on success, but need to catch errors. My usage example in the test, and now it is failing
